### PR TITLE
Add text-overflow mixin

### DIFF
--- a/mixins/visibility.scss
+++ b/mixins/visibility.scss
@@ -20,3 +20,18 @@
     text-indent: 101%;
     white-space: nowrap;
 }
+
+
+///
+/// Prevents wrapping of text by displaying ellipsis instead.
+///
+/// @example scss - Usage
+///   .element {
+///     @include text-overflow;
+///   }
+///
+@mixin text-overflow () {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/mixins/visibility.scss
+++ b/mixins/visibility.scss
@@ -27,10 +27,10 @@
 ///
 /// @example scss - Usage
 ///   .element {
-///     @include text-overflow;
+///     @include text-overflow-ellipsis;
 ///   }
 ///
-@mixin text-overflow () {
+@mixin text-overflow-ellipsis () {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Adds a commonly used mixin that prevents text wrapping and instead showing ellipsis.