### PR TITLE
Reset list styling ul + simplify button handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 
 *   Removed the mixin: `rem-to-px()`
 
-1.4 (unreleased)
+1.5
+===
+
+*   Reset list styling in `reset`.
+
+
+1.4
 ===
 
 *   Added new mixin: `centered-container()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,19 @@
 2.0 (unreleased)
 ===
 
-*   Removed the mixin: `rem-to-px()`
+*   Removed the mixin: `rem-to-px()`.
+*   Removed the mixin: `invisible-button()`.
 
 1.5
 ===
 
+*   Deprecated the mixin `invisible-button()`.
 *   Reset list styling in `reset`.
 
 
 1.4
 ===
 
-*   Added new mixin: `centered-container()`
-*   Added the mixin `normalize-to-px()` that replaces `rem-to-px()`
-*   Deprecated the mixin: `rem-to-px()`
+*   Added new mixin: `centered-container()`.
+*   Added the mixin `normalize-to-px()` that replaces `rem-to-px()`.
+*   Deprecated the mixin: `rem-to-px()`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,4 +1,6 @@
 1.x to 2.0
 ==========
 
-* The mixin `rem-to-px()` was removed. Use `normalize-to-px()` instead.
+*   The mixin `invisible-button()` was removed. The functionality was moved to the reset, so it can be removed it without any replacement.
+*   The mixin `rem-to-px()` was removed. Use `normalize-to-px()` instead.
+

--- a/mixins/buttons.scss
+++ b/mixins/buttons.scss
@@ -1,9 +1,9 @@
 ///
-/// Hides all the default styling of buttons across the browsers
+/// Hides all the default styling of buttons across the browsers.
+/// Most of the settings are done in the reset, but this one resets it completely.
+///
+/// @deprecated and superseded by `reset`.
 ///
 @mixin invisible-button {
-    outline: 0;
-    border: 0;
-    background-color: transparent;
-    cursor: pointer;
+    @debug "Using `invisible-button()` is deprecated and will be removed in 2.0. It can be removed without replacement, as the definitions have been moved to the reset.";
 }

--- a/reset.scss
+++ b/reset.scss
@@ -125,15 +125,17 @@ img {
 // Forms
 // ---------------------------------------------------------------------------------------------------------
 
+// Don't forget to style the focus state as well!
 button {
     color: inherit;
     border: 0;
     border-radius: 0;
     -webkit-font-smoothing: inherit;
     letter-spacing: inherit;
-    background: none;
+    background: none transparent;
     cursor: pointer;
     -webkit-appearance: button;
+    outline: 0;
 }
 
 button,

--- a/reset.scss
+++ b/reset.scss
@@ -1,3 +1,5 @@
+@import "mixins/lists";
+
 // This is adapted from normalize.css
 // http://necolas.github.io/normalize.css/
 
@@ -252,4 +254,16 @@ svg {
     // By default IE11 renders SVGs with overflow enabled, which can caused weird rendering issues
     overflow: hidden;
     display: inline-block;
+}
+
+
+// ---------------------------------------------------------------------------------------------------------
+// Lists
+// ---------------------------------------------------------------------------------------------------------
+
+// disable list styling on lists by default, as the styling should be set
+// explicitly in the `.content` class.
+// Only reset `ul` as `ol` is not used for navigations.
+ul {
+    list-style: none;
 }

--- a/reset.scss
+++ b/reset.scss
@@ -251,4 +251,5 @@ template {
 svg {
     // By default IE11 renders SVGs with overflow enabled, which can caused weird rendering issues
     overflow: hidden;
+    display: inline-block;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| Improvement?  | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Docs PR       | —

<!-- describe your changes below -->

* Improve reset of `ul`
* Deprecated `invisible-button()` and move the content to the reset.