### PR TITLE
Deprecated `navigation-list()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 *   Removed the mixin: `rem-to-px()`.
 *   Removed the mixin: `invisible-button()`.
+*   Removed the mixin: `navigation-list()`.
 
 1.5
 ===

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,7 @@
 1.x to 2.0
 ==========
 
+*   The mixin `navigation-list()` was removed. Remove the mixin for `<ul>`s or otherwise it must be inlined.
 *   The mixin `invisible-button()` was removed. The functionality was moved to the reset, so it can be removed it without any replacement.
 *   The mixin `rem-to-px()` was removed. Use `normalize-to-px()` instead.
 

--- a/mixins/lists.scss
+++ b/mixins/lists.scss
@@ -2,5 +2,6 @@
 /// Provides sensible defaults when using a list as navigation list
 ///
 @mixin navigation-list {
+    @debug "Using `navigation-list()` is deprecated and will be removed in 2.0. Remove the mixin for <ul>s or otherwise it must be inlined.";
     list-style: none;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| Improvement?  | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->
| BC breaks?    | no
| Deprecations? | yes
| Docs PR       | —

<!-- describe your changes below -->
Just to make it more clear, that the mixin is obsolete in most cases.