### PR TITLE
Fix broken CSS list type in transition mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.3.2
+=====
+
+*   Compile to correct CSS list type in `transition` mixin.
+
+
 2.3.1
 =====
 

--- a/mixins/transition.scss
+++ b/mixins/transition.scss
@@ -15,6 +15,6 @@
     }
     @else {
         transition: #{$duration} #{$easing};
-        transition-property: $properties;
+        transition-property: join($properties, (), 'comma');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Improvement?  | no <!-- improves an existing feature, not adding a new one --> 
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | — <!-- insert URL here -->

<!-- describe your changes below -->
Funny that nobody ever noticed that the CSS property falls back to `all`.